### PR TITLE
support individualized transforms for src blobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,18 @@ Type: `String`
 
 The path to the output concatenated JSON file.
 
-### cwd
+### base
 
 Type: `String`
 Default: `null`
 
-The root folder to source files from. This will exclude this folder and it's parents from nested layer representation in the output JSON file. If `cwd` is set, then the root folder does not need to be specified as part of the `src`.
+The root folder to source files from. This will exclude this folder and it's parents from nested layer representation in the output JSON file. If `base` is set, then the root folder does not need to be specified as part of the `src`. `cwd` may be used as an alias for `base`.
+
+### transforms
+
+Type: `Array`
+
+`base` only goes so far when `src` contains sources from different locations. In these situations, a list of `transforms` may be specified instead: one transform for each element in `src`, in order. Transforms may be strings (in which case they are applied in much the same way as `base`), or functions which take in and return a path string, which then defines the nested JSON structure.
 
 ## Task Options
 
@@ -186,6 +192,43 @@ end in a unique symbol, the default is '[]'; For the files
 
 Note, that the .json files in an array folder do not retain their file names as keys,
 since they are now array index items.
+
+## Using Transforms
+
+Assuming we have the files `source/one.json` and `somewhere/else/there/is/a/file.json`:
+
+```js
+{
+    src: ['source/**/*.json', 'somewhere/else/**/*.json'],
+    transforms: [
+        'source',
+        function(target) {
+            // extensions are stripped so target is 'somewhere/else/there/is/a/file'
+            var filename = target.split(path.sep).pop();        // grab 'file'
+
+            return ['outer', filename, 'inner'].join(path.sep); // return 'outer/file/inner'
+        }
+    ],
+    dest: 'output.json',
+}
+```
+
+The resulting `output.json` is:
+
+```js
+{
+    one: {
+        // contents of one.json
+    },
+    outer: {
+      file: {
+        inner: {
+            // contents of file.json
+        }
+      }
+    }
+}
+```
 
 ## Handling JavaScript files
 

--- a/package.json
+++ b/package.json
@@ -1,51 +1,52 @@
 {
-	"name": "grunt-concat-json",
-	"homepage": "http://github.com/SpringRoll/grunt-concat-json",
-	"description": "Grunt Task for Merging Multiple JSON Files",
-	"version": "0.0.10",
-	"license": "MIT",
-	"author": {
-		"name": "Matte Szklarz",
-		"email": "matteszklarz@cloudkid.com",
-		"url": "http://cloudkid.com"
-	},
-	"contributors": [
-		{
-			"name": "Matt Karl",
-			"email": "matt@cloudkid.com",
-			"url": "http://cloudkid.com"
-		}
-	],
-	"keywords": [
-		"gruntplugin",
-		"merge",
-		"json"
-	],
-	"repository": {
-		"type": "git",
-		"url": "git://github.com/SpringRoll/grunt-concat-json.git"
-	},
-	"bugs": {
-		"url": "http://github.com/SpringRoll/grunt-concat-json/issues"
-	},
-	"main": "./tasks/concat-json.js",
-	"devDependencies": {
-		"grunt-contrib-jshint": "~0.7.1",
-		"grunt-simple-version": "~0.2.0"
-	},
-	"peerDependencies": {
-		"grunt": "~0.4.5"
-	},
-	"dependencies": {
-		"colors": "^1.1.2",
-		"jsonlint": "~1.6.2",
-		"strip-json-comments": "~1.0.2"
-	},
-	"engines": {
-		"node": ">=0.10.0"
-	},
-	"scripts": {
-		"test": "grunt test --verbose"
-	},
-	"readmeFilename": "README.md"
+  "name": "grunt-concat-json",
+  "homepage": "http://github.com/SpringRoll/grunt-concat-json",
+  "description": "Grunt Task for Merging Multiple JSON Files",
+  "version": "0.0.10",
+  "license": "MIT",
+  "author": {
+    "name": "Matte Szklarz",
+    "email": "matteszklarz@cloudkid.com",
+    "url": "http://cloudkid.com"
+  },
+  "contributors": [
+    {
+      "name": "Matt Karl",
+      "email": "matt@cloudkid.com",
+      "url": "http://cloudkid.com"
+    }
+  ],
+  "keywords": [
+    "gruntplugin",
+    "merge",
+    "json"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/SpringRoll/grunt-concat-json.git"
+  },
+  "bugs": {
+    "url": "http://github.com/SpringRoll/grunt-concat-json/issues"
+  },
+  "main": "./tasks/concat-json.js",
+  "devDependencies": {
+    "grunt-contrib-jshint": "~0.7.1",
+    "grunt-simple-version": "~0.2.0"
+  },
+  "peerDependencies": {
+    "grunt": "~0.4.5"
+  },
+  "dependencies": {
+    "colors": "^1.1.2",
+    "jsonlint": "~1.6.2",
+    "minimatch": "^3.0.2",
+    "strip-json-comments": "~1.0.2"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "scripts": {
+    "test": "grunt test --verbose"
+  },
+  "readmeFilename": "README.md"
 }


### PR DESCRIPTION
This plugin has been super useful for breaking locale files into manageable chunks, but I've finally hit a point where I need more flexibility than just `base` by itself can handle. Here's a way to manage the JSON structure source-by-source instead of all at once.
