### PR TITLE
update dependencies, remove unused grunt-simple-version

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,7 +18,6 @@ module.exports = function(grunt)
             ]
         }
     });
-    grunt.loadNpmTasks('grunt-simple-version');
     grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.registerTask('test', ['jshint']);
     grunt.registerTask('default', ['test', 'version:current']);

--- a/package.json
+++ b/package.json
@@ -30,17 +30,16 @@
   },
   "main": "./tasks/concat-json.js",
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.7.1",
-    "grunt-simple-version": "~0.2.0"
+    "grunt-contrib-jshint": "^1.1.0"
   },
   "peerDependencies": {
-    "grunt": "~0.4.5"
+    "grunt": "~1.0.1"
   },
   "dependencies": {
     "colors": "^1.1.2",
     "jsonlint": "~1.6.2",
     "minimatch": "^3.0.2",
-    "strip-json-comments": "~1.0.2"
+    "strip-json-comments": "^2.0.1"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
We're moving to Grunt 1.0 but still need this. I just removed the simple-version plugin since it didn't appear to be used in the Gruntfile. There don't appear to be any changes necessary in the code.

If this update is alright by you all, could you please bump the version and publish once this is integrated?